### PR TITLE
Added provider emote id in returned emote json

### DIFF
--- a/temotes/emote.go
+++ b/temotes/emote.go
@@ -24,7 +24,8 @@ type EmoteUrl struct {
 }
 
 type Emote struct {
-	Provider EmoteProvider `json:"provider"`
-	Code     string        `json:"code"`
-	Urls     []EmoteUrl    `json:"urls"`
+	ProviderEmoteID string        `json:"provider_emote_id"`
+	Provider        EmoteProvider `json:"provider"`
+	Code            string        `json:"code"`
+	Urls            []EmoteUrl    `json:"urls"`
 }

--- a/temotes/providers/7tv.go
+++ b/temotes/providers/7tv.go
@@ -76,8 +76,9 @@ func (t SevenTvFetcher) parseEmoteUrls(emote sevenTvEmote) []temotes.EmoteUrl {
 
 func (t SevenTvFetcher) parseEmote(emote sevenTvEmote) temotes.Emote {
 	return temotes.Emote{
-		Provider: temotes.Provider7tv,
-		Code:     emote.Code,
-		Urls:     t.parseEmoteUrls(emote),
+		ProviderEmoteID: emote.ID,
+		Provider:        temotes.Provider7tv,
+		Code:            emote.Code,
+		Urls:            t.parseEmoteUrls(emote),
 	}
 }

--- a/temotes/providers/bttv.go
+++ b/temotes/providers/bttv.go
@@ -82,8 +82,9 @@ func (t BttvFetcher) parseEmoteUrls(emote bttvEmote) []temotes.EmoteUrl {
 
 func (t BttvFetcher) parseEmote(emote bttvEmote) temotes.Emote {
 	return temotes.Emote{
-		Provider: temotes.ProviderBttv,
-		Code:     emote.Code,
-		Urls:     t.parseEmoteUrls(emote),
+		ProviderEmoteID: emote.ID,
+		Provider:        temotes.ProviderBttv,
+		Code:            emote.Code,
+		Urls:            t.parseEmoteUrls(emote),
 	}
 }

--- a/temotes/providers/ffz.go
+++ b/temotes/providers/ffz.go
@@ -7,6 +7,7 @@ import (
 	"sort"
 	"temotes/temotes"
 	"time"
+	"strconv"
 )
 
 type FfzFetcher struct{}
@@ -90,8 +91,9 @@ func (t FfzFetcher) parseEmoteUrls(emote ffzEmote) []temotes.EmoteUrl {
 
 func (t FfzFetcher) parseEmote(emote ffzEmote) temotes.Emote {
 	return temotes.Emote{
-		Provider: temotes.ProviderFfz,
-		Code:     emote.Code,
-		Urls:     t.parseEmoteUrls(emote),
+		ProviderEmoteID: strconv.Itoa(emote.ID),
+		Provider:        temotes.ProviderFfz,
+		Code:            emote.Code,
+		Urls:            t.parseEmoteUrls(emote),
 	}
 }

--- a/temotes/providers/twitch.go
+++ b/temotes/providers/twitch.go
@@ -162,9 +162,10 @@ func (t TwitchFetcher) parseEmoteUrls(emote twitchEmote) []temotes.EmoteUrl {
 
 func (t TwitchFetcher) parseEmote(emote twitchEmote) temotes.Emote {
 	return temotes.Emote{
-		Provider: temotes.ProviderTwitch,
-		Code:     emote.Code,
-		Urls:     t.parseEmoteUrls(emote),
+		ProviderEmoteID: emote.ID,
+		Provider:        temotes.ProviderTwitch,
+		Code:            emote.Code,
+		Urls:            t.parseEmoteUrls(emote),
 	}
 }
 


### PR DESCRIPTION
Issue: 
Creating unique key or filename for each of the emote (for emotes like "Harambe" it's ok, but what for ":)" where ":" character is invalid for a filename)

Possible solution:
Parsing the unique key from the URL of the emote. However, it's time-consuming and what if the URL changes?

Simple solution:
I propose in this pull request just passing emotes ID returned by twitch/7tv/bttv/ffz to the Emote object, so it can be returned by tEmotes API. This way, unique keys (or file names) for each emotes can be easily created by combining its ID and the provider's name (for example: 60ae7316f7c927fad14e6ca2_7tv.webp)

I hope this will be accepted as these IDs can come in handy for anyone using the tEmotes API :)